### PR TITLE
REP-289 - When attempting to save "Roles and Permissions" on the user edit page, the organizations get saved instead

### DIFF
--- a/src/actions/usersActions.ts
+++ b/src/actions/usersActions.ts
@@ -308,3 +308,25 @@ export const editUserOrganizations = (userId: string, organizationIds: string[])
         });
     }
 };
+
+export const editUserRoles = (userId: string, roleIds: string[]) => async (dispatch: Dispatch<any>) => {
+    dispatch({
+        type: usersActionTypes.USERS_EDIT_PENDING
+    });
+
+    try {
+        await userService.editUserRoles(userId, roleIds);
+        dispatch(change('userManagementForm', 'activePanelIndex', null));
+        dispatch({
+            type: usersActionTypes.USERS_EDIT_SUCCESS
+        });
+        loadManagementInitialUser(userId)(dispatch);
+    } catch (e) {
+        dispatch({
+            type: usersActionTypes.USERS_EDIT_ERROR,
+            payload: {
+                message: getErrorMessageFromStatusCode(e.response != null ? e.response.status : null)
+            }
+        });
+    }
+};

--- a/src/components/users/userManagementForm.tsx
+++ b/src/components/users/userManagementForm.tsx
@@ -22,6 +22,7 @@ interface UserManagementProps {
     editUserOrganizations(): void;
     editUserGeneral(): void;
     editUserEmails(): void;
+    editUserRoles(): void;
     navigateToUsers(): void;
     removeEmailAddress(): void;
     removeOrganization(organizationId: string): void;
@@ -98,7 +99,7 @@ const UserManagementForm: React.SFC<UserManagementProps> = (props: UserManagemen
                                                 toggleRoleDetails={props.toggleRoleDetails.bind(this)}
                                                 removeRole={props.removeRole.bind(this)}
                                                 organizations={props.organizations}
-                                                onSubmit={props.editUserOrganizations.bind(this)}/>
+                                                onSubmit={props.editUserRoles.bind(this)}/>
                 </Panel>
                 <UserManagementControls right={false} 
                                         children={null} 

--- a/src/containers/users/userManagementFormContainer.tsx
+++ b/src/containers/users/userManagementFormContainer.tsx
@@ -3,7 +3,7 @@ import {bindActionCreators} from "redux";
 import { State } from '../../store/initialState';
 import { selectOrganization, addOrganization, removeOrganization, clearManagementInitialUser, loadManagementInitialUser, toggleRoleDetails, 
     addRole, removeRole, selectRole, removeEmailAddress, setPrimaryEmailAddress, addEmailAddress, togglePanel, cancelUserPanel, editUserGeneral, 
-    editUserEmails, editUserOrganizations} from '../../actions/usersActions';
+    editUserEmails, editUserOrganizations, editUserRoles } from '../../actions/usersActions';
 import { getOrganizations } from '../../actions/organizationsActions';
 import { getRoles } from '../../actions/rolesActions';
 import { sendVerificationEmail } from '../../actions/authActions';
@@ -121,6 +121,16 @@ class UserManagementFormContainer extends React.Component<RouteComponentProps<an
         this.props.actions.editUserOrganizations(form.id, selectedOrganizations);
     }
 
+
+    editUserRoles(form: UserManagementFormValues) {
+        const selectedRoles = form.selectedRoles
+            .map((role: SelectedRole) => {
+                return role.value
+            });
+
+        this.props.actions.editUserRoles(this.props.user.id, selectedRoles);
+    }
+
     render() {
         return (
             <UserManagementForm activePanelIndex={this.props.activePanelIndex}
@@ -131,6 +141,7 @@ class UserManagementFormContainer extends React.Component<RouteComponentProps<an
                                 editUserEmails={this.editUserEmails.bind(this)}
                                 editUserGeneral={this.editUserGeneral.bind(this)}
                                 editUserOrganizations={this.editUserOrganizations.bind(this)}
+                                editUserRoles={this.editUserRoles.bind(this)}
                                 navigateToUsers={this.navigateToUsers.bind(this)} 
                                 organizations={this.props.organizations}
                                 redirectToErrorPage={this.props.redirectToErrorPage}
@@ -194,7 +205,8 @@ function mapActionToProps(dispatch: any) {
                 editUserGeneral,
                 submitForm,
                 editUserEmails,
-                editUserOrganizations
+                editUserOrganizations,
+                editUserRoles
             }, dispatch)
         };
     }


### PR DESCRIPTION
…by onSubmit in the userManagementRolesForm to editUserRoles instead of editUserOrganizations